### PR TITLE
moved import of polyfill. removed CDN of polyfill in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,6 @@
     <meta http-equiv="x-ua-compatible" content="IE=edge" >
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.11.5/polyfill.js" integrity="sha512-wixq/u8vbwoVM6yCmTHUNszWudaPpwf8pKxfG1NPUOBXTh1ntBx8sr/dJSbGTlZUqpcoPjaUmU1hlBB3oJlzFQ==" crossorigin="anonymous"></script>
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <title>Pain Management Summary</title>

--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -1,3 +1,4 @@
+import '../helpers/polyfill';
 import React, { Component } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -10,7 +11,6 @@ import Summary from './Summary';
 import Spinner from '../elements/Spinner';
 import executeExternalCDSCall from "../utils/executeExternalCDSHooksCall";
 import executeInternalCDSCall from "../utils/executeInternalCDSHooksCall";
-import '../helpers/polyfill';
 import { Hook, Console, Decode } from 'console-feed'
 require('es6-promise').polyfill();
 require('fetch-everywhere');

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -1,5 +1,5 @@
-import FHIR from 'fhirclient';
 import './helpers/polyfill';
+import FHIR from 'fhirclient';
 require('fetch-everywhere');
 
 fetch(process.env.PUBLIC_URL + '/launch-context.json')


### PR DESCRIPTION
UCM encountered an issue where the application is not allowed to get the polyfill from the CDN. CDN was removed, and polyfill import order was changed. Tested on IE10 in VirtualBox to be working.

To test:
I use http-server package to get an accurate server with which to test the build. These polyfills only work in a production build. 

— Yarn build
— http-server ./build
— navigate browser to provided URL.
